### PR TITLE
refactor: 챗봇 대화 저장 로직 수정

### DIFF
--- a/utils/autoCloseExpiredConversations.js
+++ b/utils/autoCloseExpiredConversations.js
@@ -1,7 +1,7 @@
 // utils/autoCloseExpiredConversations.js
 const Conversation = require('../models/Conversation');
 
-const CONVERSATION_TIMEOUT =  60 * 1000; // 15분(테스트 용으로 1분)
+const CONVERSATION_TIMEOUT =  60 * 1000; // 15분(테스트 용으로1분)
 
 async function expireOldConversations() {
   const expiredTime = new Date(Date.now() - CONVERSATION_TIMEOUT);
@@ -23,6 +23,7 @@ async function expireOldConversations() {
       timestamp: new Date(),
     });
 
+    convo.markModified('messages');
     await convo.save();
     console.log('✅ 종료 메시지 추가됨:', convo._id);
   }


### PR DESCRIPTION
- 사용자가 입력 없이 챗봇을 닫은 경우, 다음 방문 시 이전 대화를 불러오지 않고 초기 인사말 + 추천 질문을 보여줌
- DB에는 인사말 및 추천 질문은 저장하지 않음
- 사용자 입력이 있는 경우에만 이전 대화를 복원함
